### PR TITLE
Language Correction

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -165,7 +165,7 @@ RegisterNetEvent("skapPersonalStashes:showEmployeeMenu", function(employees)
     end
     lib.registerContext({
         id = "employee_stash_menu",
-        title = "👤 Anställdas förråd",
+        title = "👤Employee storage",
         options = options
     })
 


### PR DESCRIPTION
Line 168 The Employee Storage Header Was Named Anställdas förråd So i changed it back to English!